### PR TITLE
Resolved the issue about @jpmorganchase/perspective module.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@jpmorganchase/perspective": "^0.2.12",
-    "@jpmorganchase/perspective-viewer": "^0.2.12",
-    "@jpmorganchase/perspective-viewer-highcharts": "^0.2.12",
+    "@finos/perspective": "^0.6.2",
+    "@finos/perspective-viewer": "^0.6.2",
+    "@finos/perspective-viewer-highcharts": "^0.5.2",
     "@types/jest": "^23.3.13",
     "@types/node": "^10.12.19",
     "@types/react": "^16.9.0",

--- a/src/Graph.tsx
+++ b/src/Graph.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Table } from '@jpmorganchase/perspective';
+import { Table } from '@finos/perspective';
 import { ServerRespond } from './DataStreamer';
 import './Graph.css';
 


### PR DESCRIPTION
Changes in the name of jpmorganchase packages were causing "Cannot find module '@jpmorganchase/perspective'. " error when "npm install" command are run. Out-of-dated packages are updated.